### PR TITLE
fix: style.css media-query for mobile devices

### DIFF
--- a/source/css/style.css
+++ b/source/css/style.css
@@ -10,7 +10,7 @@
   src: local('Noto Sans'), url(../fonts/NotoSansHant-Regular.otf) format('otf');
 }
 
-@media only screen and (min-device-width: 810px) {
+@media only screen {
 
 body {
     font: normal 14px;


### PR DESCRIPTION
Current `@media only screen and (min-device-width: 810px)` prevents mobile devices to load major styles, hence the book contents are nearly un-styled (refer to the screenshot from iPad below).

@[http://learnyouahaskell-zh-tw.csie.org/css/style.css](http://learnyouahaskell-zh-tw.csie.org/css/style.css):L13

``` css
@media only screen and (min-device-width: 810px) {
body {
    font: normal 14px;
    font-family: "Noto Sans", Optima, Ubuntu, Verdana, "Hiragino Sans GB", "wenquanyi micro hei", Arial,serif,Courier New,黑体;
}
// ...
ul.nav li { display: block; max-width: 250px; height: 30px; font-size:17px; width: 33% }
// ...
ul.nav .right { right: 10px; float: right; text-align: right; }
// ...
div#main {
    max-width: 810px;
    margin: 10px auto 0 auto;
}
// ...
}
```

This commit removes the `min-device-width` condition.

![photo dec 28 11 44 50 am](https://cloud.githubusercontent.com/assets/80781/5563064/bc92d37a-8e8e-11e4-8124-f198bd293579.png)
